### PR TITLE
Fixed cuda pinning for cuda and pytorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 69b3aa435f2424ac6a1bfb6ff702da6eb73b33ca0db38fb26989c74159258e47
 
 build:
-  number: 11
+  number: 12
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   skip: true  # [win]
@@ -35,10 +35,11 @@ requirements:
     - pytorch
     - pytorch =*={{ torch_proc_type }}*
     - pytest-runner
-    - libcusparse-dev    # [(cuda_compiler_version or "").startswith("12")]
-    - libcublas-dev      # [(cuda_compiler_version or "").startswith("12")]
-    - libcusolver-dev    # [(cuda_compiler_version or "").startswith("12")]
-    - libxcrypt          # [linux and py<39]
+    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+    - libcusparse-dev                           # [(cuda_compiler_version or "").startswith("12")]
+    - libcublas-dev                             # [(cuda_compiler_version or "").startswith("12")]
+    - libcusolver-dev                           # [(cuda_compiler_version or "").startswith("12")]
+    - libxcrypt                                 # [linux and py<39]
   run:
     - python
     - python-wget

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
     - libcusparse-dev                           # [(cuda_compiler_version or "").startswith("12")]
     - libcublas-dev                             # [(cuda_compiler_version or "").startswith("12")]
     - libcusolver-dev                           # [(cuda_compiler_version or "").startswith("12")]
-    - libxcrypt                                 # [linux and py<39]
   run:
     - python
     - python-wget


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Similar to https://github.com/conda-forge/pytorch_sparse-feedstock/pull/71 the pins for cuda weren't ensuring a consistent version of cuda, resulting in dependency inconsistencies.

Unlike that diff where I pinned cuda to existing cuda packages, I'm adding the `cuda-version` package with correct pinning to the host section.